### PR TITLE
Set default timeout request to 60 seconds

### DIFF
--- a/OX3_Api_Client.php
+++ b/OX3_Api_Client.php
@@ -34,7 +34,7 @@ class OX3_Api_Client extends Zend_Rest_Client
         }
         
         // Initilize the cookie jar, from the $cookieJarFile if present
-        $client = self::getHttpClient();
+        $client = self::getHttpClient()->setConfig(array('timeout' => 60));
         $cookieJar = false;
         if (is_readable($cookieJarFile)) {
             $cookieJar = @unserialize(file_get_contents($cookieJarFile));


### PR DESCRIPTION
I've caught a lot of 'Zend_Http_Client_Adapter_Exception' with message 'Read timed out after 10 seconds', what made impossible to consume the OpenX API by batch scripts.