### PR TITLE
IR-506 + API-4809 - make it accept a single object payload in POST + Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# zend 2 is provided by the image, though we could switch to composer
+FROM jeffersonvv/zend2
+
+# then two dependencies of OX lib
+RUN composer require zendframework/zendoauth
+RUN composer require zendframework/zendrest
+# and just throw it into vendor (so it can load dependencies)
+# vendor = /var/www/zend/vendor
+COPY OX3_Api_Client2.php vendor/
+
+
+# if you wanna try debugging with Charles:
+#RUN wget www.charlesproxy.com/getssl
+#RUN mkdir /usr/local/share/ca-certificates/charles
+#RUN mv getssl /usr/local/share/ca-certificates/charles/charles.crt
+#RUN chmod 755 /usr/local/share/ca-certificates/charles
+#RUN chmod 644 /usr/local/share/ca-certificates/charles/charles.crt
+# these seem ignored
+#ENV http_proxy=http://host.docker.internal:8888
+#ENV https_proxy=https://host.docker.internal:8888

--- a/OX3_Api_Client2.php
+++ b/OX3_Api_Client2.php
@@ -166,9 +166,16 @@ class OX3_Api_Client2 extends ZendRest\Client\RestClient
             if (!isset($args[0])) {
                 $args[0] = $this->uri->getPath();
             }
-            if (isset($args[1]) && is_array($args[1])) {
-                foreach ($args[1] as $key => $value) {
-                    $this->data[$key] = $value;
+
+            if (isset($args[1])) {
+                if (is_array($args[1])) {
+                    # not sure why we are doing this
+                    foreach ($args[1] as $key => $value) {
+                        $this->data[$key] = $value;
+                    }
+                }
+                elseif (is_string($args[1]) || is_object($args[1])) {
+                    $this->data = $args[1];
                 }
             }
             //$this->_data['rest'] = 1;


### PR DESCRIPTION
The problem was that when a single object was passed to `POST` when making a request, it wasn't actually copied to the post body, instead the default empty array was used.